### PR TITLE
Add more bunks to the Izar Gunship, so it can actually have 5 turrets.

### DIFF
--- a/LUPAINIANS/data/LNS_ships.txt
+++ b/LUPAINIANS/data/LNS_ships.txt
@@ -7,7 +7,7 @@ ship "Izar Gunship"
 		"shields" 24800
 		"hull" 9900
 		"required crew" 14
-		"bunks" 18
+		"bunks" 23
 		"mass" 350
 		"drag" 5.7
 		"heat dissipation" .75


### PR DESCRIPTION
added 5, to keep the intended 4 free bunks with all turrets installed.